### PR TITLE
add missing include

### DIFF
--- a/src/neo/assert.cpp
+++ b/src/neo/assert.cpp
@@ -1,5 +1,6 @@
 #include "./assert.hpp"
 
+#include <exception>
 #include <iostream>
 
 namespace {


### PR DESCRIPTION
To fix observed error building https://github.com/mongodb-labs/mongo-c-driver-async on macOS:
```
/Users/kevin.albertson/code/mongo-c-driver-async/_build/_deps/neo-fun-src/src/neo/assert.cpp:44:10: error: no member named 'terminate' in namespace 'std'; did you mean 'template'?
   44 |     std::terminate();
      |     ~~~~~^~~~~~~~~
      |          template
```